### PR TITLE
Transmission: facilitate start and stop

### DIFF
--- a/arm/transmission/transmission.service
+++ b/arm/transmission/transmission.service
@@ -8,6 +8,7 @@ Restart=always
 RestartSec=10s
 TimeoutStartSec=0
 ExecStartPre=-/bin/sh -c "mkdir -p /storage/%p/watch /storage/%p/downloads /storage/%p/incomplete /storage/%p/config"
+ExecStartPre=-/storage/.kodi/addons/service.system.docker/bin/docker rm %p
 ExecStart=/storage/.kodi/addons/service.system.docker/bin/docker run \
           --rm \
           --name=%p \
@@ -19,7 +20,7 @@ ExecStart=/storage/.kodi/addons/service.system.docker/bin/docker run \
           --publish=9091:9091 \
           --publish=45555:45555 \
           libreelecarm/%p
-ExecStop=/storage/.kodi/addons/service.system.docker/bin/docker stop %p
+ExecStop=/storage/.kodi/addons/service.system.docker/bin/docker kill %p
 
 [Install]
 WantedBy=multi-user.target

--- a/x86_64/transmission/transmission.service
+++ b/x86_64/transmission/transmission.service
@@ -8,6 +8,7 @@ Restart=always
 RestartSec=10s
 TimeoutStartSec=0
 ExecStartPre=-/bin/sh -c "mkdir -p /storage/%p/watch /storage/%p/downloads /storage/%p/incomplete /storage/%p/config"
+ExecStartPre=-/storage/.kodi/addons/service.system.docker/bin/docker rm %p
 ExecStart=/storage/.kodi/addons/service.system.docker/bin/docker run \
           --rm \
           --name=%p \
@@ -19,7 +20,7 @@ ExecStart=/storage/.kodi/addons/service.system.docker/bin/docker run \
           --publish=9091:9091 \
           --publish=45555:45555 \
           libreelec/%p
-ExecStop=/storage/.kodi/addons/service.system.docker/bin/docker stop %p
+ExecStop=/storage/.kodi/addons/service.system.docker/bin/docker kill %p
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This fixes two problems:
- remove spurious containers (likely due to abnormal service termination) before start
- use kill, rather than stop, which is inoperative and delays service termination by 10 seconds.